### PR TITLE
Fix UI auth status display and update default extraction mode

### DIFF
--- a/src/ui/popup/App.jsx
+++ b/src/ui/popup/App.jsx
@@ -8,7 +8,7 @@ function App() {
   const [cachedOrders, setCachedOrders] = useState(0);
   const [syncStatus, setSyncStatus] = useState(null);
   const [isSyncing, setIsSyncing] = useState(false);
-  const [mode, setMode] = useState("auto");
+  const [mode, setMode] = useState("content");
   const [useCache, setUseCache] = useState(true);
   const [results, setResults] = useState(null);
   const [error, setError] = useState(null);
@@ -187,7 +187,8 @@ function App() {
 
   // Render progress
   const renderProgress = () => {
-    if (!syncStatus || syncStatus.status === "idle") return null;
+    // Only show sync status when actually syncing
+    if (!isSyncing || !syncStatus || syncStatus.status === "idle") return null;
 
     const { status, details } = syncStatus;
     const statusText = status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
@@ -343,9 +344,9 @@ function App() {
           <div className="select-group">
             <label htmlFor="modeSelect">Extraction Mode:</label>
             <select id="modeSelect" value={mode} onChange={(e) => setMode(e.target.value)}>
+              <option value="content">Content Script (Recommended)</option>
               <option value="auto">Auto (API → Content Script)</option>
               <option value="api">API Only (Fast)</option>
-              <option value="content">Content Script Only (Reliable)</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- Fixed auth status disconnect in popup UI where it showed "Checking Auth" even when logged in
- Changed default extraction mode to "Content Script" for better reliability
- Improved UI clarity around sync status

## Changes
1. **Fixed auth status display logic**: Modified `renderProgress()` to only show sync status when actively syncing (`isSyncing` is true), preventing confusing "Checking Auth" message when already authenticated
2. **Updated default extraction mode**: Changed from "auto" to "content" as requested for better reliability
3. **Reordered extraction mode options**: Put "Content Script (Recommended)" first in the dropdown

## Test Plan
- [x] Verified auth status displays correctly when logged in
- [x] Confirmed default extraction mode is now "Content Script"
- [x] Tested sync status only appears during active sync operations
- [x] All lint, format, and type checks pass